### PR TITLE
optimize batch insert action

### DIFF
--- a/src/test/scala/io/getquill/context/finagle/mysql/FinagleMysqlContextSpec.scala
+++ b/src/test/scala/io/getquill/context/finagle/mysql/FinagleMysqlContextSpec.scala
@@ -4,9 +4,9 @@ import java.util.TimeZone
 import com.twitter.finagle.mysql
 import com.twitter.finagle.mysql.{EmptyValue, Error, IsolationLevel}
 import com.twitter.util._
-import io.getquill.context.sql.{OkTestClient, TestDecoders, TestEncoders, TestEntities}
 import io.getquill.FinagleMysqlContext
 import io.getquill.Literal
+import io.getquill.context.test.{OkTestClient, TestDecoders, TestEncoders, TestEntities}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
@@ -16,7 +16,7 @@ class FinagleMysqlContextSpec extends AnyFreeSpec with Matchers with BeforeAndAf
   val context = testContext
   import testContext._
 
-  def await[T](f: Future[T]) = Await.result(f)
+  def await[T](f: Future[T]): T = Await.result(f)
 
   "run non-batched action" in {
     val insert = quote { (i: Int) =>
@@ -93,7 +93,7 @@ class FinagleMysqlContextSpec extends AnyFreeSpec with Matchers with BeforeAndAf
       override def toOk(result: mysql.Result) = super.toOk(result)
     }
     intercept[IllegalStateException](ctx.toOk(Error(-1, "no ok", "test")))
-    ctx.close
+    ctx.close()
   }
 
   "prepare" in {

--- a/src/test/scala/io/getquill/context/finagle/mysql/TestContext.scala
+++ b/src/test/scala/io/getquill/context/finagle/mysql/TestContext.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.finagle.mysql
 
 import io.getquill.{FinagleMysqlContext, Literal}
-import io.getquill.context.sql.{TestDecoders, TestEncoders, TestEntities}
+import io.getquill.context.test.{TestDecoders, TestEncoders, TestEntities}
 
 object testContext
     extends FinagleMysqlContext(

--- a/src/test/scala/io/getquill/context/finagle/mysql/example/CaseClassQueryFinagleMysqlSpec.scala
+++ b/src/test/scala/io/getquill/context/finagle/mysql/example/CaseClassQueryFinagleMysqlSpec.scala
@@ -2,7 +2,7 @@ package io.getquill.context.finagle.mysql.example
 
 import com.twitter.util.{Await, Future}
 import io.getquill.context.finagle.mysql.testContext
-import io.getquill.context.sql.example.CaseClassQuerySpec
+import io.getquill.context.test.example.CaseClassQuerySpec
 import org.scalatest.matchers.should.Matchers._
 
 class CaseClassQueryFinagleMysqlSpec extends CaseClassQuerySpec {

--- a/src/test/scala/io/getquill/context/finagle/mysql/example/DepartmentsFinagleMysqlSpec.scala
+++ b/src/test/scala/io/getquill/context/finagle/mysql/example/DepartmentsFinagleMysqlSpec.scala
@@ -2,7 +2,7 @@ package io.getquill.context.finagle.mysql.example
 
 import com.twitter.util.{Await, Future}
 import io.getquill.context.finagle.mysql.testContext
-import io.getquill.context.sql.example.DepartmentsSpec
+import io.getquill.context.test.example.DepartmentsSpec
 
 class DepartmentsFinagleMysqlSpec extends DepartmentsSpec {
 

--- a/src/test/scala/io/getquill/context/finagle/mysql/example/OnConflictFinagleMysqlSpec.scala
+++ b/src/test/scala/io/getquill/context/finagle/mysql/example/OnConflictFinagleMysqlSpec.scala
@@ -2,7 +2,7 @@ package io.getquill.context.finagle.mysql.example
 
 import com.twitter.util.{Await, Future}
 import io.getquill.context.finagle.mysql.testContext
-import io.getquill.context.sql.example.OnConflictSpec
+import io.getquill.context.test.example.OnConflictSpec
 
 class OnConflictFinagleMysqlSpec extends OnConflictSpec {
   val ctx = testContext

--- a/src/test/scala/io/getquill/context/finagle/mysql/example/OptionalNestedFinagleMysqlSpec.scala
+++ b/src/test/scala/io/getquill/context/finagle/mysql/example/OptionalNestedFinagleMysqlSpec.scala
@@ -2,7 +2,7 @@ package io.getquill.context.finagle.mysql.example
 
 import com.twitter.util.{Await, Future}
 import io.getquill.context.finagle.mysql.testContext
-import io.getquill.context.sql.example.OptionalNestedSpec
+import io.getquill.context.test.example.OptionalNestedSpec
 
 class OptionalNestedFinagleMysqlSpec extends OptionalNestedSpec {
 

--- a/src/test/scala/io/getquill/context/finagle/mysql/example/PeopleFinagleMysqlSpec.scala
+++ b/src/test/scala/io/getquill/context/finagle/mysql/example/PeopleFinagleMysqlSpec.scala
@@ -2,7 +2,7 @@ package io.getquill.context.finagle.mysql.example
 
 import com.twitter.util.{Await, Future}
 import io.getquill.context.finagle.mysql.testContext
-import io.getquill.context.sql.example.PeopleSpec
+import io.getquill.context.test.example.PeopleSpec
 
 class PeopleFinagleMysqlSpec extends PeopleSpec {
 

--- a/src/test/scala/io/getquill/context/finagle/mysql/example/ProductFinagleMysqlSpec.scala
+++ b/src/test/scala/io/getquill/context/finagle/mysql/example/ProductFinagleMysqlSpec.scala
@@ -2,7 +2,7 @@ package io.getquill.context.finagle.mysql.example
 
 import com.twitter.util.{Await, Future}
 import io.getquill.context.finagle.mysql.testContext
-import io.getquill.context.sql.example.{Id, ProductSpec}
+import io.getquill.context.test.example.{Id, ProductSpec}
 
 class ProductFinagleMysqlSpec extends ProductSpec {
 
@@ -18,8 +18,9 @@ class ProductFinagleMysqlSpec extends ProductSpec {
 
   "Product" - {
     "Insert multiple products" in {
-      val inserted = await(Future.collect(productEntries.map(product => testContext.run(productInsert(lift(product))))))
-      val product  = await(testContext.run(productById(lift(inserted(2))))).head
+      val inserted =
+        await(Future.collect(productEntries.map(product => testContext.run(productInsertReturningId(lift(product))))))
+      val product = await(testContext.run(productById(lift(inserted(2))))).head
       product.description mustEqual productEntries(2).description
       product.id mustEqual inserted(2)
     }
@@ -57,7 +58,7 @@ class ProductFinagleMysqlSpec extends ProductSpec {
 
     "Single product insert with a method quotation" in {
       val prd             = Product(0L, "test3", 3L)
-      val inserted        = await(testContext.run(productInsert(lift(prd))))
+      val inserted        = await(testContext.run(productInsertReturningId(lift(prd))))
       val returnedProduct = await(testContext.run(productById(lift(inserted)))).head
       returnedProduct.description mustEqual "test3"
       returnedProduct.sku mustEqual 3L

--- a/src/test/scala/io/getquill/context/finagle/mysql/sql/FinagleMysqlDeleteSpec.scala
+++ b/src/test/scala/io/getquill/context/finagle/mysql/sql/FinagleMysqlDeleteSpec.scala
@@ -1,0 +1,30 @@
+package io.getquill.context.finagle.mysql.sql
+
+import com.twitter.util.{Await, Future}
+import io.getquill.context.finagle.mysql.testContext
+import io.getquill.context.test.LogCapture
+import io.getquill.context.test.sql.QuerySpec
+import org.scalatest.BeforeAndAfterEach
+
+class FinagleMysqlDeleteSpec extends QuerySpec with BeforeAndAfterEach with LogCapture {
+
+  val context = testContext
+  import testContext._
+
+  def await[T](r: Future[T]): T = Await.result(r)
+
+  override def beforeEach(): Unit = {
+    await(testContext.run(deleteAll))
+    ()
+  }
+
+  "delete" - {
+    "batch which is not optimized" in {
+      val (logs, _) = logCapture {
+        await(testContext.run(liftQuery(productEntries).foreach(e => query[Product].filter(_.id == e.id).delete)))
+      }
+      val occurrence = logs.split("""DELETE FROM Product x1 WHERE x1.id = \?""").length - 1
+      occurrence must be(3)
+    }
+  }
+}

--- a/src/test/scala/io/getquill/context/finagle/mysql/sql/FinagleMysqlEncodingSpec.scala
+++ b/src/test/scala/io/getquill/context/finagle/mysql/sql/FinagleMysqlEncodingSpec.scala
@@ -1,14 +1,13 @@
-package io.getquill.context.finagle.mysql
+package io.getquill.context.finagle.mysql.sql
+
+import com.twitter.util.Await
+import io.getquill.context.finagle.mysql.testContext
+import io.getquill.context.test.sql.EncodingSpec
+import io.getquill.util.LoadConfig
+import io.getquill.{FinagleMysqlContext, FinagleMysqlContextConfig, Literal, Query}
 
 import java.time.{LocalDate, LocalDateTime, ZoneId}
 import java.util.{Date, TimeZone}
-
-import com.twitter.util.Await
-import io.getquill.util.LoadConfig
-import io.getquill.{FinagleMysqlContext, FinagleMysqlContextConfig, Literal}
-import io.getquill.Query
-import io.getquill.context.sql.example.EncodingSpec
-
 import scala.concurrent.duration._
 
 class FinagleMysqlEncodingSpec extends EncodingSpec {

--- a/src/test/scala/io/getquill/context/finagle/mysql/sql/FinagleMysqlInsertSpec.scala
+++ b/src/test/scala/io/getquill/context/finagle/mysql/sql/FinagleMysqlInsertSpec.scala
@@ -1,0 +1,36 @@
+package io.getquill.context.finagle.mysql.sql
+
+import com.twitter.util.{Await, Future}
+import io.getquill.context.finagle.mysql.testContext
+import io.getquill.context.test.LogCapture
+import io.getquill.context.test.sql.QuerySpec
+import org.scalatest.BeforeAndAfterEach
+
+class FinagleMysqlInsertSpec extends QuerySpec with BeforeAndAfterEach with LogCapture {
+
+  val context = testContext
+  import testContext._
+
+  def await[T](r: Future[T]): T = Await.result(r)
+
+  override def beforeEach(): Unit = {
+    await(testContext.run(deleteAll))
+    ()
+  }
+
+  "insert" - {
+    "batch which is optimized as bulk insert action" in {
+      val (logs, _) = logCapture {
+        await(testContext.run(liftQuery(productEntries).foreach(e => productInsert(e))))
+      }
+      logs must include("INSERT INTO Product (id,description,sku) VALUES (?, ?, ?), (?, ?, ?), (?, ?, ?)")
+    }
+    "batch returning which is not optimized" in {
+      val (logs, _) = logCapture {
+        await(testContext.run(liftQuery(productEntries).foreach(e => productInsertReturningId(e))))
+      }
+      val occurrence = logs.split("""INSERT INTO Product \(description,sku\) VALUES \(\?, \?\)""").length - 1
+      occurrence must be(3)
+    }
+  }
+}

--- a/src/test/scala/io/getquill/context/finagle/mysql/sql/FinagleMysqlSelectSpec.scala
+++ b/src/test/scala/io/getquill/context/finagle/mysql/sql/FinagleMysqlSelectSpec.scala
@@ -1,13 +1,13 @@
-package io.getquill.context.finagle.mysql.example
+package io.getquill.context.finagle.mysql.sql
 
 import com.twitter.util.{Await, Future}
 import io.getquill.context.finagle.mysql.testContext
-import io.getquill.context.sql.example.QueryResultTypeSpec
+import io.getquill.context.test.sql.QuerySpec
 
 import java.util.concurrent.ConcurrentLinkedQueue
 import scala.jdk.CollectionConverters._
 
-class QueryResultTypeFinagleMysqlSpec extends QueryResultTypeSpec {
+class FinagleMysqlSelectSpec extends QuerySpec {
 
   val context = testContext
   import testContext._
@@ -18,7 +18,7 @@ class QueryResultTypeFinagleMysqlSpec extends QueryResultTypeSpec {
 
   override def beforeAll(): Unit = {
     await(testContext.run(deleteAll))
-    val rs = await(testContext.run(liftQuery(productEntries).foreach(e => productInsert(e))))
+    val rs = await(testContext.run(liftQuery(productEntries).foreach(e => productInsertReturningId(e))))
     val inserted = (rs zip productEntries).map { case (r, prod) =>
       prod.copy(id = r)
     }

--- a/src/test/scala/io/getquill/context/finagle/mysql/sql/FinagleMysqlUpdateSpec.scala
+++ b/src/test/scala/io/getquill/context/finagle/mysql/sql/FinagleMysqlUpdateSpec.scala
@@ -1,0 +1,32 @@
+package io.getquill.context.finagle.mysql.sql
+
+import com.twitter.util.{Await, Future}
+import io.getquill.context.finagle.mysql.testContext
+import io.getquill.context.test.LogCapture
+import io.getquill.context.test.sql.QuerySpec
+import org.scalatest.BeforeAndAfterEach
+
+class FinagleMysqlUpdateSpec extends QuerySpec with BeforeAndAfterEach with LogCapture {
+
+  val context = testContext
+  import testContext._
+
+  def await[T](r: Future[T]): T = Await.result(r)
+
+  override def beforeEach(): Unit = {
+    await(testContext.run(deleteAll))
+    ()
+  }
+
+  "update" - {
+    "batch which is not optimized" in {
+      val (logs, _) = logCapture {
+        await(testContext.run(liftQuery(productEntries).foreach { e =>
+          query[Product].filter(_.id == e.id).update(_.description -> "updated")
+        }))
+      }
+      val occurrence = logs.split("""UPDATE Product x1 SET description = 'updated' WHERE x1.id = \?""").length - 1
+      occurrence must be(3)
+    }
+  }
+}

--- a/src/test/scala/io/getquill/context/test/LogCapture.scala
+++ b/src/test/scala/io/getquill/context/test/LogCapture.scala
@@ -1,0 +1,21 @@
+package io.getquill.context.test
+
+import java.io.{ByteArrayOutputStream, PrintStream}
+import scala.util.control.Exception.ultimately
+
+trait LogCapture {
+
+  def logCapture[A](f: => A): (String, A) = {
+    val outputStream = new ByteArrayOutputStream()
+    val printStream  = new PrintStream(outputStream)
+    val sysOut       = System.out
+    val ret = ultimately(System.setOut(sysOut)) {
+      System.setOut(printStream)
+      Console.withOut(printStream)(f)
+    }
+    val logs = outputStream.toString
+    println(logs)
+    (logs, ret)
+  }
+
+}

--- a/src/test/scala/io/getquill/context/test/OkTestClient.scala
+++ b/src/test/scala/io/getquill/context/test/OkTestClient.scala
@@ -1,4 +1,4 @@
-package io.getquill.context.sql
+package io.getquill.context.test
 
 import com.twitter.concurrent.AsyncStream
 import com.twitter.finagle.mysql

--- a/src/test/scala/io/getquill/context/test/TestDecoders.scala
+++ b/src/test/scala/io/getquill/context/test/TestDecoders.scala
@@ -1,7 +1,8 @@
-package io.getquill.context.sql
+package io.getquill.context.test
 
 import io.getquill.MappedEncoding
-import io.getquill.context.sql.example.EncodingTestType
+import io.getquill.context.test
+import io.getquill.context.test.sql.EncodingTestType
 
 /**
  * https://github.com/zio/zio-quill/blob/bf18ce1add6d0ce0ad4109cdaba2a4bece47f48c/quill-sql/src/test/scala/io/getquill/context/sql/TestDecoders.scala
@@ -9,8 +10,8 @@ import io.getquill.context.sql.example.EncodingTestType
 trait TestDecoders {
   implicit val encodingTestTypeDecoder: MappedEncoding[String, EncodingTestType] =
     MappedEncoding[String, EncodingTestType](EncodingTestType)
-  implicit val nameDecoder: MappedEncoding[String, example.Number] = MappedEncoding[String, example.Number](s =>
-    example.Number
+  implicit val nameDecoder: MappedEncoding[String, test.sql.Number] = MappedEncoding[String, test.sql.Number](s =>
+    test.sql.Number
       .withValidation(s)
       .getOrElse(throw new Exception(s"Illegal number $s"))
   )

--- a/src/test/scala/io/getquill/context/test/TestEncoders.scala
+++ b/src/test/scala/io/getquill/context/test/TestEncoders.scala
@@ -1,7 +1,7 @@
-package io.getquill.context.sql
+package io.getquill.context.test
 
 import io.getquill.MappedEncoding
-import io.getquill.context.sql.example.{EncodingTestType, Number}
+import io.getquill.context.test.sql.EncodingTestType
 
 /**
  * @see
@@ -10,5 +10,5 @@ import io.getquill.context.sql.example.{EncodingTestType, Number}
 trait TestEncoders {
   implicit val encodingTestTypeEncoder: MappedEncoding[EncodingTestType, String] =
     MappedEncoding[EncodingTestType, String](_.value)
-  implicit val nameEncoder: MappedEncoding[Number, String] = MappedEncoding[Number, String](_.value)
+  implicit val nameEncoder: MappedEncoding[sql.Number, String] = MappedEncoding[sql.Number, String](_.value)
 }

--- a/src/test/scala/io/getquill/context/test/TestEntities.scala
+++ b/src/test/scala/io/getquill/context/test/TestEntities.scala
@@ -1,4 +1,4 @@
-package io.getquill.context.sql
+package io.getquill.context.test
 
 import io.getquill.context.Context
 import io.getquill.quat.Quat

--- a/src/test/scala/io/getquill/context/test/example/CaseClassQuerySpec.scala
+++ b/src/test/scala/io/getquill/context/test/example/CaseClassQuerySpec.scala
@@ -1,4 +1,4 @@
-package io.getquill.context.sql.example
+package io.getquill.context.test.example
 
 import io.getquill.context.sql.SqlContext
 import org.scalatest.BeforeAndAfterAll

--- a/src/test/scala/io/getquill/context/test/example/DepartmentsSpec.scala
+++ b/src/test/scala/io/getquill/context/test/example/DepartmentsSpec.scala
@@ -1,4 +1,4 @@
-package io.getquill.context.sql.example
+package io.getquill.context.test.example
 
 import io.getquill.{EntityQuery, Query, Quoted}
 import io.getquill.context.sql.SqlContext

--- a/src/test/scala/io/getquill/context/test/example/OnConflictSpec.scala
+++ b/src/test/scala/io/getquill/context/test/example/OnConflictSpec.scala
@@ -1,6 +1,7 @@
-package io.getquill.context.sql.example
+package io.getquill.context.test.example
 
-import io.getquill.context.sql.{SqlContext, TestEntities}
+import io.getquill.context.sql.SqlContext
+import io.getquill.context.test.TestEntities
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers

--- a/src/test/scala/io/getquill/context/test/example/OptionalNestedSpec.scala
+++ b/src/test/scala/io/getquill/context/test/example/OptionalNestedSpec.scala
@@ -1,4 +1,4 @@
-package io.getquill.context.sql.example
+package io.getquill.context.test.example
 
 import io.getquill.Insert
 import io.getquill.context.Context

--- a/src/test/scala/io/getquill/context/test/example/PeopleSpec.scala
+++ b/src/test/scala/io/getquill/context/test/example/PeopleSpec.scala
@@ -1,4 +1,4 @@
-package io.getquill.context.sql.example
+package io.getquill.context.test.example
 
 import io.getquill.context.sql.SqlContext
 import io.getquill.{Ord, Query, Quoted}
@@ -162,8 +162,8 @@ trait PeopleSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll {
   }
   val `Ex 11 filtered update expected` =
     peopleEntries.map {
-      case Person("Bert", age) => Person("Bert", 44)
-      case other               => other
+      case Person("Bert", _) => Person("Bert", 44)
+      case other             => other
     }
 
   val `Ex 12 filtered update co-related` = quote {
@@ -176,7 +176,7 @@ trait PeopleSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll {
   }
   val `Ex 12 filtered update co-related expected` =
     peopleEntries.map {
-      case Person("Bert", age) => Person("Bert", 45)
-      case other               => other
+      case Person("Bert", _) => Person("Bert", 45)
+      case other             => other
     }
 }

--- a/src/test/scala/io/getquill/context/test/example/ProductSpec.scala
+++ b/src/test/scala/io/getquill/context/test/example/ProductSpec.scala
@@ -1,4 +1,4 @@
-package io.getquill.context.sql.example
+package io.getquill.context.test.example
 
 import io.getquill.Query
 import io.getquill.context.sql.SqlContext
@@ -25,21 +25,25 @@ trait ProductSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll {
   }
 
   val productInsert = quote { (p: Product) =>
+    query[Product].insertValue(p)
+  }
+
+  val productInsertReturningId = quote { (p: Product) =>
     query[Product].insertValue(p).returningGenerated(_.id)
   }
 
   val productInsertBatch = quote { (b: Query[Product]) =>
-    b.foreach(p => productInsert.apply(p))
+    b.foreach(p => productInsertReturningId.apply(p))
   }
 
-  def productById = quote { (id: Long) =>
+  val productById = quote { (id: Long) =>
     product.filter(_.id == id)
   }
 
   val productEntries = List(
     Product(0L, "Notebook", 1001L),
-    Product(0L, "Soap", 1002L),
-    Product(0L, "Pencil", 1003L)
+    Product(1L, "Soap", 1002L),
+    Product(2L, "Pencil", 1003L)
   )
 
   val productSingleInsert = quote {

--- a/src/test/scala/io/getquill/context/test/sql/EncodingSpec.scala
+++ b/src/test/scala/io/getquill/context/test/sql/EncodingSpec.scala
@@ -1,6 +1,7 @@
-package io.getquill.context.sql.example
+package io.getquill.context.test.sql
 
-import io.getquill.context.sql.{SqlContext, TestDecoders, TestEncoders}
+import io.getquill.context.sql.SqlContext
+import io.getquill.context.test.{TestDecoders, TestEncoders}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers

--- a/src/test/scala/io/getquill/context/test/sql/QuerySpec.scala
+++ b/src/test/scala/io/getquill/context/test/sql/QuerySpec.scala
@@ -1,12 +1,13 @@
-package io.getquill.context.sql.example
+package io.getquill.context.test.sql
 
 import io.getquill.Ord
+import io.getquill.context.test.example.ProductSpec
 
 /**
  * @see
  *   [[https://github.com/zio/zio-quill/blob/bf18ce1add6d0ce0ad4109cdaba2a4bece47f48c/quill-sql/src/test/scala/io/getquill/context/sql/base/QueryResultTypeSpec.scala]]
  */
-trait QueryResultTypeSpec extends ProductSpec {
+trait QuerySpec extends ProductSpec {
 
   import context._
 


### PR DESCRIPTION
## Problem

```scala
quote {
  liftQuery(products).foreach(e => query[Product].insertValue(e))
}
```

batch insert generate following queries.

```sql
INSERT INTO Product VALUES (?, ?)
INSERT INTO Product VALUES (?, ?)
```

These queries are executed by `twitter.Future.collect` but it's too slow.

## Optimize

Now generate following query.

```sql
INSERT INTO Product VALUES (?, ?), (?, ?)
```